### PR TITLE
Fix mago binary download to match new release asset naming

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,23 +1,8 @@
 name: mago
 
-post_install_actions:
-  - |
-    #ddev-description: Install mago binary into web container
-    if [ -z "${MAGO_VERSION:-}" ]; then
-      MAGO_VERSION=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest | grep '"tag_name"' | cut -d '"' -f4)
-    fi
-    ARCH=$(uname -m)
-    if [ "$ARCH" = "aarch64" ]; then
-      TARGET="aarch64-unknown-linux-musl"
-    else
-      TARGET="x86_64-unknown-linux-musl"
-    fi
-    curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${TARGET}.tar.gz" \
-      | tar -xz -C /usr/local/bin mago
-    chmod +x /usr/local/bin/mago
-
 project_files:
   - commands/web/mago
+  - web-build/Dockerfile.mago
 
 removal_actions:
-  - ddev exec rm -f /usr/local/bin/mago
+  - rm web-build/Dockerfile.mago

--- a/web-build/Dockerfile.mago
+++ b/web-build/Dockerfile.mago
@@ -1,0 +1,14 @@
+#ddev-generated
+ARG MAGO_VERSION=""
+RUN if [ -z "${MAGO_VERSION}" ]; then \
+      MAGO_VERSION=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest | grep '"tag_name"' | cut -d '"' -f4); \
+    fi && \
+    ARCH=$(uname -m) && \
+    if [ "$ARCH" = "aarch64" ]; then \
+      TARGET="aarch64-unknown-linux-musl"; \
+    else \
+      TARGET="x86_64-unknown-linux-musl"; \
+    fi && \
+    curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-${TARGET}.tar.gz" \
+      | tar -xz -C /usr/local/bin --strip-components=1 "mago-${MAGO_VERSION}-${TARGET}/mago" && \
+    chmod +x /usr/local/bin/mago


### PR DESCRIPTION
## Summary
- The mago project now includes the version in the release asset filename (e.g. `mago-1.14.1-x86_64-unknown-linux-musl.tar.gz` instead of `mago-x86_64-unknown-linux-musl.tar.gz`)
- The tarball also now contains a versioned subdirectory, so `tar` extraction needed `--strip-components=1`