### PR TITLE
Add update check on startup and support for version pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,32 @@ ddev mago analyze                 # Run static analysis
 ddev mago --version               # Show installed version
 ```
 
-## Pinning a Mago version
+## Updating
 
-By default, the add-on installs the latest Mago release. To pin a specific version:
+The add-on checks for new Mago releases on `ddev start` (once per day) and notifies you when an update is available. To update:
 
 ```bash
-ddev dotenv set .ddev/.env.mago --mago-version=0.0.22
 ddev add-on get amateescu/ddev-mago
 ddev restart
 ```
 
-Make sure to commit the `.ddev/.env.mago` file to version control.
+## Pinning a Mago version
+
+By default, the add-on installs the latest Mago release. To pin a specific version, add `MAGO_VERSION` to `web_environment` in your `.ddev/config.yaml`:
+
+```yaml
+web_environment:
+  - MAGO_VERSION=1.14.1
+```
+
+Then restart: `ddev restart`
+
+To unpin and go back to the latest version, remove the `MAGO_VERSION` entry and run:
+
+```bash
+ddev add-on get amateescu/ddev-mago
+ddev restart
+```
 
 ## Configuration
 

--- a/commands/web/mago
+++ b/commands/web/mago
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+#ddev-generated
 ## Description: Run Mago PHP toolchain (lint, format, analyze, check)
 ## Usage: mago [command] [flags] [paths]
 ## Example: "ddev mago lint" or "ddev mago format --check" or "ddev mago analyze"

--- a/config.mago.yaml
+++ b/config.mago.yaml
@@ -1,0 +1,44 @@
+#ddev-generated
+hooks:
+  post-start:
+    - exec: |
+        CURRENT=$(mago --version 2>/dev/null | awk '{print $2}')
+        if [ -z "$CURRENT" ]; then
+          exit 0
+        fi
+
+        # If a specific version is pinned and it doesn't match, install it.
+        if [ -n "${MAGO_VERSION:-}" ] && [ "$CURRENT" != "$MAGO_VERSION" ]; then
+          echo "Installing pinned mago version $MAGO_VERSION (current: $CURRENT)..."
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "aarch64" ]; then
+            TARGET="aarch64-unknown-linux-musl"
+          else
+            TARGET="x86_64-unknown-linux-musl"
+          fi
+          curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-${TARGET}.tar.gz" \
+            | tar -xz -C /usr/local/bin --strip-components=1 "mago-${MAGO_VERSION}-${TARGET}/mago"
+          chmod +x /usr/local/bin/mago
+          exit 0
+        fi
+
+        # Otherwise, check for updates (cached, once per day).
+        CACHE_FILE="/mnt/ddev_config/addon-metadata/mago/.latest_version"
+        CACHE_MAX_AGE=86400
+        LATEST=""
+        if [ -f "$CACHE_FILE" ]; then
+          CACHE_AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE") ))
+          if [ "$CACHE_AGE" -lt "$CACHE_MAX_AGE" ]; then
+            LATEST=$(cat "$CACHE_FILE")
+          fi
+        fi
+        if [ -z "$LATEST" ]; then
+          LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
+          if [ -n "$LATEST" ]; then
+            echo "$LATEST" > "$CACHE_FILE"
+          fi
+        fi
+        if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
+          echo "A new version of mago is available: $LATEST (current: $CURRENT)"
+          echo "Run 'ddev add-on get amateescu/ddev-mago && ddev restart' to update."
+        fi

--- a/config.mago.yaml
+++ b/config.mago.yaml
@@ -16,8 +16,11 @@ hooks:
           else
             TARGET="x86_64-unknown-linux-musl"
           fi
-          curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-${TARGET}.tar.gz" \
-            | tar -xz -C /usr/local/bin --strip-components=1 "mago-${MAGO_VERSION}-${TARGET}/mago"
+          if ! curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-${TARGET}.tar.gz" \
+            | tar -xz -C /usr/local/bin --strip-components=1 "mago-${MAGO_VERSION}-${TARGET}/mago"; then
+            echo "Failed to install mago version $MAGO_VERSION. Check that this version exists."
+            exit 1
+          fi
           chmod +x /usr/local/bin/mago
           exit 0
         fi

--- a/install.yaml
+++ b/install.yaml
@@ -7,3 +7,5 @@ project_files:
 
 removal_actions:
   - rm web-build/Dockerfile.mago
+  - rm config.mago.yaml
+  - rm -f addon-metadata/mago/.latest_version

--- a/install.yaml
+++ b/install.yaml
@@ -3,6 +3,7 @@ name: mago
 project_files:
   - commands/web/mago
   - web-build/Dockerfile.mago
+  - config.mago.yaml
 
 removal_actions:
   - rm web-build/Dockerfile.mago

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -86,6 +86,36 @@ teardown() {
   assert_success
 }
 
+@test "version pinning via web_environment" {
+  set -eu -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+
+  # Pin an older version.
+  echo -e "web_environment:\n  - MAGO_VERSION=1.13.0" > .ddev/config.mago-test.yaml
+  run ddev restart -y
+  assert_success
+  run ddev mago --version
+  assert_success
+  assert_output --partial "1.13.0"
+}
+
+@test "update notification for outdated version" {
+  set -eu -o pipefail
+  run ddev add-on get "${DIR}"
+  assert_success
+  run ddev restart -y
+  assert_success
+
+  # Seed the cache with a fake newer version to trigger the notification.
+  echo "99.99.99" > .ddev/addon-metadata/mago/.latest_version
+  run ddev restart -y
+  assert_success
+  assert_output --partial "A new version of mago is available: 99.99.99"
+}
+
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail


### PR DESCRIPTION
## Summary
- Notify users about new mago releases on `ddev start` (cached, once per day)
- Support version pinning via `MAGO_VERSION` in `web_environment`
- Update README with new Updating and Pinning sections