### PR TITLE
Drop update check cache and simplify Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ ddev mago --version               # Show installed version
 
 ## Updating
 
-The add-on checks for new Mago releases on `ddev start` (once per day) and notifies you when an update is available. To update:
+The add-on checks for new Mago releases on `ddev start` and notifies you when an update is available. To update:
 
 ```bash
 ddev add-on get amateescu/ddev-mago

--- a/config.mago.yaml
+++ b/config.mago.yaml
@@ -25,22 +25,8 @@ hooks:
           exit 0
         fi
 
-        # Otherwise, check for updates (cached, once per day).
-        CACHE_FILE="/mnt/ddev_config/addon-metadata/mago/.latest_version"
-        CACHE_MAX_AGE=86400
-        LATEST=""
-        if [ -f "$CACHE_FILE" ]; then
-          CACHE_AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE_FILE") ))
-          if [ "$CACHE_AGE" -lt "$CACHE_MAX_AGE" ]; then
-            LATEST=$(cat "$CACHE_FILE")
-          fi
-        fi
-        if [ -z "$LATEST" ]; then
-          LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
-          if [ -n "$LATEST" ]; then
-            echo "$LATEST" > "$CACHE_FILE"
-          fi
-        fi
+        # Otherwise, check for updates.
+        LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
         if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
           echo "A new version of mago is available: $LATEST (current: $CURRENT)"
           echo "Run 'ddev add-on get amateescu/ddev-mago && ddev restart' to update."

--- a/install.yaml
+++ b/install.yaml
@@ -8,4 +8,3 @@ project_files:
 removal_actions:
   - rm web-build/Dockerfile.mago
   - rm config.mago.yaml
-  - rm -f addon-metadata/mago/.latest_version

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -102,20 +102,6 @@ teardown() {
   assert_output --partial "1.13.0"
 }
 
-@test "update notification for outdated version" {
-  set -eu -o pipefail
-  run ddev add-on get "${DIR}"
-  assert_success
-  run ddev restart -y
-  assert_success
-
-  # Seed the cache with a fake newer version to trigger the notification.
-  echo "99.99.99" > .ddev/addon-metadata/mago/.latest_version
-  run ddev restart -y
-  assert_success
-  assert_output --partial "A new version of mago is available: 99.99.99"
-}
-
 # bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail

--- a/web-build/Dockerfile.mago
+++ b/web-build/Dockerfile.mago
@@ -1,8 +1,5 @@
 #ddev-generated
-ARG MAGO_VERSION=""
-RUN if [ -z "${MAGO_VERSION}" ]; then \
-      MAGO_VERSION=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest | grep '"tag_name"' | cut -d '"' -f4); \
-    fi && \
+RUN MAGO_VERSION=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest | grep '"tag_name"' | cut -d '"' -f4) && \
     ARCH=$(uname -m) && \
     if [ "$ARCH" = "aarch64" ]; then \
       TARGET="aarch64-unknown-linux-musl"; \


### PR DESCRIPTION
## Summary
- Fix read-only filesystem error when writing cache to `addon-metadata/mago/`
- Drop the cache entirely — just check the GitHub API on each `ddev start`
- Remove unused `ARG MAGO_VERSION` from Dockerfile since DDEV can't pass build args