### PR TITLE
Auto-update mago binary on ddev start

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,11 @@ ddev mago --version               # Show installed version
 
 ## Updating
 
-The add-on checks for new Mago releases on `ddev start` and notifies you when an update is available. To update:
-
-```bash
-ddev add-on get amateescu/ddev-mago
-ddev restart
-```
+The mago binary is automatically updated to the latest release on every `ddev start`.
 
 ## Pinning a Mago version
 
-By default, the add-on installs the latest Mago release. To pin a specific version, add `MAGO_VERSION` to `web_environment` in your `.ddev/config.yaml`:
+To pin a specific version, add `MAGO_VERSION` to `web_environment` in your `.ddev/config.yaml`:
 
 ```yaml
 web_environment:
@@ -45,12 +40,7 @@ web_environment:
 
 Then restart: `ddev restart`
 
-To unpin and go back to the latest version, remove the `MAGO_VERSION` entry and run:
-
-```bash
-ddev add-on get amateescu/ddev-mago
-ddev restart
-```
+To unpin and go back to the latest version, remove the `MAGO_VERSION` entry and restart.
 
 ## Configuration
 

--- a/config.mago.yaml
+++ b/config.mago.yaml
@@ -7,27 +7,39 @@ hooks:
           exit 0
         fi
 
-        # If a specific version is pinned and it doesn't match, install it.
-        if [ -n "${MAGO_VERSION:-}" ] && [ "$CURRENT" != "$MAGO_VERSION" ]; then
-          echo "Installing pinned mago version $MAGO_VERSION (current: $CURRENT)..."
+        install_mago() {
+          VERSION=$1
           ARCH=$(uname -m)
           if [ "$ARCH" = "aarch64" ]; then
             TARGET="aarch64-unknown-linux-musl"
           else
             TARGET="x86_64-unknown-linux-musl"
           fi
-          if ! curl -fsSL "https://github.com/carthage-software/mago/releases/download/${MAGO_VERSION}/mago-${MAGO_VERSION}-${TARGET}.tar.gz" \
-            | tar -xz -C /usr/local/bin --strip-components=1 "mago-${MAGO_VERSION}-${TARGET}/mago"; then
+          if ! curl -fsSL "https://github.com/carthage-software/mago/releases/download/${VERSION}/mago-${VERSION}-${TARGET}.tar.gz" \
+            | tar -xz -C /usr/local/bin --strip-components=1 "mago-${VERSION}-${TARGET}/mago"; then
+            return 1
+          fi
+          chmod +x /usr/local/bin/mago
+        }
+
+        # If a specific version is pinned and it doesn't match, install it.
+        if [ -n "${MAGO_VERSION:-}" ] && [ "$CURRENT" != "$MAGO_VERSION" ]; then
+          echo "Installing pinned mago version $MAGO_VERSION (current: $CURRENT)..."
+          if ! install_mago "$MAGO_VERSION"; then
             echo "Failed to install mago version $MAGO_VERSION. Check that this version exists."
             exit 1
           fi
-          chmod +x /usr/local/bin/mago
           exit 0
         fi
 
-        # Otherwise, check for updates.
-        LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
-        if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
-          echo "A new version of mago is available: $LATEST (current: $CURRENT)"
-          echo "Run 'ddev add-on get amateescu/ddev-mago && ddev restart' to update."
+        # Otherwise, check for updates and install if available.
+        if [ -z "${MAGO_VERSION:-}" ]; then
+          LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
+          if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
+            echo "Updating mago from $CURRENT to $LATEST..."
+            if ! install_mago "$LATEST"; then
+              echo "Failed to update mago to $LATEST."
+              exit 1
+            fi
+          fi
         fi


### PR DESCRIPTION
## Summary
- Instead of just notifying about new versions, the post-start hook now automatically updates the mago binary to the latest release
- Refactored the download logic into a shared `install_mago` function used by both version pinning and auto-update
- Simplified README update instructions