### PR TITLE
Rename MAGO_VERSION to DDEV_MAGO_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ The mago binary is automatically updated to the latest release on every `ddev st
 
 ## Pinning a Mago version
 
-To pin a specific version, add `MAGO_VERSION` to `web_environment` in your `.ddev/config.yaml`:
+To pin a specific version, add `DDEV_MAGO_VERSION` to `web_environment` in your `.ddev/config.yaml`:
 
 ```yaml
 web_environment:
-  - MAGO_VERSION=1.14.1
+  - DDEV_MAGO_VERSION=1.24.0
 ```
 
 Then restart: `ddev restart`
 
-To unpin and go back to the latest version, remove the `MAGO_VERSION` entry and restart.
+To unpin and go back to the latest version, remove the `DDEV_MAGO_VERSION` entry and restart.
 
 ## Configuration
 

--- a/config.mago.yaml
+++ b/config.mago.yaml
@@ -23,17 +23,17 @@ hooks:
         }
 
         # If a specific version is pinned and it doesn't match, install it.
-        if [ -n "${MAGO_VERSION:-}" ] && [ "$CURRENT" != "$MAGO_VERSION" ]; then
-          echo "Installing pinned mago version $MAGO_VERSION (current: $CURRENT)..."
-          if ! install_mago "$MAGO_VERSION"; then
-            echo "Failed to install mago version $MAGO_VERSION. Check that this version exists."
+        if [ -n "${DDEV_MAGO_VERSION:-}" ] && [ "$CURRENT" != "$DDEV_MAGO_VERSION" ]; then
+          echo "Installing pinned mago version $DDEV_MAGO_VERSION (current: $CURRENT)..."
+          if ! install_mago "$DDEV_MAGO_VERSION"; then
+            echo "Failed to install mago version $DDEV_MAGO_VERSION. Check that this version exists."
             exit 1
           fi
           exit 0
         fi
 
         # Otherwise, check for updates and install if available.
-        if [ -z "${MAGO_VERSION:-}" ]; then
+        if [ -z "${DDEV_MAGO_VERSION:-}" ]; then
           LATEST=$(curl -fsSL https://api.github.com/repos/carthage-software/mago/releases/latest 2>/dev/null | grep '"tag_name"' | cut -d '"' -f4)
           if [ -n "$LATEST" ] && [ "$CURRENT" != "$LATEST" ]; then
             echo "Updating mago from $CURRENT to $LATEST..."

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -94,12 +94,12 @@ teardown() {
   assert_success
 
   # Pin an older version.
-  echo -e "web_environment:\n  - MAGO_VERSION=1.13.0" > .ddev/config.mago-test.yaml
+  echo -e "web_environment:\n  - DDEV_MAGO_VERSION=1.23.0" > .ddev/config.mago-test.yaml
   run ddev restart -y
   assert_success
   run ddev mago --version
   assert_success
-  assert_output --partial "1.13.0"
+  assert_output --partial "1.23.0"
 }
 
 # bats test_tags=release

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -94,12 +94,12 @@ teardown() {
   assert_success
 
   # Pin an older version.
-  echo -e "web_environment:\n  - DDEV_MAGO_VERSION=1.23.0" > .ddev/config.mago-test.yaml
+  echo -e "web_environment:\n  - DDEV_MAGO_VERSION=1.22.0" > .ddev/config.mago-test.yaml
   run ddev restart -y
   assert_success
   run ddev mago --version
   assert_success
-  assert_output --partial "1.23.0"
+  assert_output --partial "1.22.0"
 }
 
 # bats test_tags=release


### PR DESCRIPTION
The `MAGO_` prefix is reserved by mago for config overrides, so `MAGO_VERSION` made every mago invocation fail. Switch the pin variable to `DDEV_MAGO_VERSION` and refresh the example/test versions.

Fixes #4 